### PR TITLE
Channelの情報を保持する型を実装した

### DIFF
--- a/StreamGetter.xcodeproj/project.pbxproj
+++ b/StreamGetter.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AC46F04B2A138F3200DCA267 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC46F04A2A138F3200DCA267 /* ContentView.swift */; };
 		AC46F04D2A138F3300DCA267 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC46F04C2A138F3300DCA267 /* Assets.xcassets */; };
 		AC46F0502A138F3300DCA267 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC46F04F2A138F3300DCA267 /* Preview Assets.xcassets */; };
+		AC46F0582A13978B00DCA267 /* ChannelModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC46F0572A13978B00DCA267 /* ChannelModels.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +20,7 @@
 		AC46F04A2A138F3200DCA267 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AC46F04C2A138F3300DCA267 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AC46F04F2A138F3300DCA267 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		AC46F0572A13978B00DCA267 /* ChannelModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelModels.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +55,7 @@
 			children = (
 				AC46F0482A138F3200DCA267 /* StreamGetterApp.swift */,
 				AC46F04A2A138F3200DCA267 /* ContentView.swift */,
+				AC46F0562A13977E00DCA267 /* Model */,
 				AC46F04C2A138F3300DCA267 /* Assets.xcassets */,
 				AC46F04E2A138F3300DCA267 /* Preview Content */,
 			);
@@ -65,6 +68,14 @@
 				AC46F04F2A138F3300DCA267 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		AC46F0562A13977E00DCA267 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				AC46F0572A13978B00DCA267 /* ChannelModels.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -138,6 +149,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AC46F04B2A138F3200DCA267 /* ContentView.swift in Sources */,
+				AC46F0582A13978B00DCA267 /* ChannelModels.swift in Sources */,
 				AC46F0492A138F3200DCA267 /* StreamGetterApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamGetter/Model/ChannelModels.swift
+++ b/StreamGetter/Model/ChannelModels.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+/// JSONファイルのitemsをデコードした結果を保持する型
+struct ChannelResponse: Codable {
+    let items: [ChannelItem]
+}
+
 /// JSONファイルのitems.itemをデコードした結果を保持する型
 struct ChannelItem: Codable {
     let snippet: ChannelSnippet

--- a/StreamGetter/Model/ChannelModels.swift
+++ b/StreamGetter/Model/ChannelModels.swift
@@ -1,0 +1,27 @@
+//
+//  ChannelModels.swift
+//  StreamGetter
+//
+//  Created by オナガ・ハルキ on 2023/05/16.
+//
+
+import Foundation
+
+/// JSONファイルのitems.item.snippetをデコードした結果を保持する型
+struct ChannelSnippet: Codable {
+    let channelId: String
+    let channelTitle: String
+    let description: String
+    let thumbnails: Thumbnails
+    let liveBroadcastContent: String
+    
+    struct Thumbnails: Codable {
+        let `default`: Thumbnail
+        let medium: Thumbnail
+        let high: Thumbnail
+        
+        struct Thumbnail: Codable {
+            let url: String
+        }
+    }
+}

--- a/StreamGetter/Model/ChannelModels.swift
+++ b/StreamGetter/Model/ChannelModels.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+/// JSONファイルのitems.itemをデコードした結果を保持する型
+struct ChannelItem: Codable {
+    let snippet: ChannelSnippet
+}
+
 /// JSONファイルのitems.item.snippetをデコードした結果を保持する型
 struct ChannelSnippet: Codable {
     let channelId: String

--- a/StreamGetter/Model/ChannelModels.swift
+++ b/StreamGetter/Model/ChannelModels.swift
@@ -7,6 +7,21 @@
 
 import Foundation
 
+/// 1つのチャンネルの情報を保持する型
+struct Channel: Identifiable {
+    let id: String
+    let channelTitle: String
+    let description: String
+    let thumbnailURL: URL
+    
+    init(item: ChannelItem) {
+        self.id = item.snippet.channelId
+        self.channelTitle = item.snippet.channelTitle
+        self.description = item.snippet.description
+        self.thumbnailURL = URL(string: item.snippet.thumbnails.default.url)!
+    }
+}
+
 /// JSONファイルのitemsをデコードした結果を保持する型
 struct ChannelResponse: Codable {
     let items: [ChannelItem]


### PR DESCRIPTION
YouTube API v3から取得したJSONファイルをデコードした結果を保持する型を実装した．
- ChannelSnippet
- ChannelItem
- ChannelResponse

YouTubeの1つのチャンネルの情報を保持する型を実装した．
- Channel